### PR TITLE
ci: fix publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -12,6 +12,9 @@ concurrency:
 jobs:
   publish:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
 
     steps:
       - uses: actions/checkout@v4
@@ -24,6 +27,6 @@ jobs:
 
       - name: Publish to npm
         working-directory: packages/mcp-auth
-        run: pnpm publish
+        run: pnpm publish --provenance --no-git-checks
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_AUTOMATION_TOKEN }}


### PR DESCRIPTION
- skip branch check as we're publishing on tags (not the main branch)
- add provenance as GitHub Actions naturally supports it