### PR TITLE
ci: update env name

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -30,4 +30,4 @@ jobs:
         working-directory: packages/mcp-auth
         run: pnpm publish --provenance --no-git-checks
         env:
-          NPM_AUTH_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_AUTOMATION_TOKEN }}


### PR DESCRIPTION
use job env to make publish work

## Testing

[successfully published](https://github.com/mcp-auth/js/actions/runs/14841743149)