### PR TITLE
refactor: support verbose mode for server config validation

### DIFF
--- a/packages/mcp-auth/package.json
+++ b/packages/mcp-auth/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mcp-auth",
-  "version": "0.1.0-beta.1",
+  "version": "0.1.0-beta.2",
   "author": "Silverhand Inc. <contact@silverhand.io>",
   "description": "Plug and play auth for Model Context Protocol (MCP) servers",
   "keywords": [

--- a/packages/mcp-auth/src/utils/validate-server-config.test.ts
+++ b/packages/mcp-auth/src/utils/validate-server-config.test.ts
@@ -23,6 +23,7 @@ describe('validateServerConfig', () => {
 
     const result = validateServerConfig(config);
     expect(result.isValid).toBe(true);
+    expect(result).not.toHaveProperty('successes');
     expect(result).not.toHaveProperty('errors');
     expect(result.warnings).toEqual([]);
   });
@@ -93,6 +94,36 @@ describe('validateServerConfig', () => {
     expect(result.errors).toEqual(
       expect.arrayContaining([
         expect.objectContaining({ code: 's256_code_challenge_method_not_supported' }),
+      ])
+    );
+  });
+});
+
+describe('validateServerConfig with verbose mode', () => {
+  it('should return successes when verbose is true', () => {
+    const config: AuthServerConfig = {
+      type: 'oauth',
+      metadata: {
+        issuer: 'https://example.com',
+        authorizationEndpoint: 'https://example.com/oauth/authorize',
+        tokenEndpoint: 'https://example.com/oauth/token',
+        responseTypesSupported: ['code'],
+        grantTypesSupported: ['authorization_code'],
+        codeChallengeMethodsSupported: ['S256'],
+        registrationEndpoint: 'https://example.com/register',
+      },
+    };
+
+    const result = validateServerConfig(config, true);
+    expect(result.isValid).toBe(true);
+    expect(result.successes).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ code: 'server_metadata_valid' }),
+        expect.objectContaining({ code: 'code_response_type_supported' }),
+        expect.objectContaining({ code: 'authorization_code_grant_supported' }),
+        expect.objectContaining({ code: 'pkce_supported' }),
+        expect.objectContaining({ code: 's256_code_challenge_method_supported' }),
+        expect.objectContaining({ code: 'dynamic_registration_supported' }),
       ])
     );
   });


### PR DESCRIPTION
set the `successes` array for detailed validation info when `verbose=true`