### PR TITLE
refactor: fall back to default grant types for config validation

### DIFF
--- a/packages/mcp-auth/src/types/oauth.ts
+++ b/packages/mcp-auth/src/types/oauth.ts
@@ -127,3 +127,10 @@ export const camelCaseAuthorizationServerMetadataSchema = z.object(
 export type CamelCaseAuthorizationServerMetadata = z.infer<
   typeof camelCaseAuthorizationServerMetadataSchema
 >;
+
+export const defaultValues: Readonly<Partial<CamelCaseAuthorizationServerMetadata>> = Object.freeze(
+  {
+    grantTypesSupported: ['authorization_code', 'implicit'],
+    responseModesSupported: ['query', 'fragment'],
+  }
+);

--- a/packages/mcp-auth/src/utils/validate-server-config.ts
+++ b/packages/mcp-auth/src/utils/validate-server-config.ts
@@ -1,7 +1,7 @@
 import { condObject } from '@silverhand/essentials';
 
 import { type AuthServerConfig } from '../types/auth-server.js';
-import { camelCaseAuthorizationServerMetadataSchema } from '../types/oauth.js';
+import { camelCaseAuthorizationServerMetadataSchema, defaultValues } from '../types/oauth.js';
 
 /**
  * The codes for successful validation of the authorization server metadata.
@@ -197,7 +197,11 @@ export const validateServerConfig: ValidateServerConfig = (config, verbose = fal
     successes.push(createSuccess('code_response_type_supported'));
   }
 
-  if (!metadata.grantTypesSupported?.includes('authorization_code')) {
+  if (
+    !(metadata.grantTypesSupported ?? defaultValues.grantTypesSupported)?.includes(
+      'authorization_code'
+    )
+  ) {
     errors.push(createError('authorization_code_grant_not_supported'));
   } else if (verbose) {
     successes.push(createSuccess('authorization_code_grant_supported'));


### PR DESCRIPTION
## Summary

Fixes #27.

When validating the server's config, `grant_type_supported` should fall back to `["authorization_code", "implicit"]` if the value is not present in the provided data. This behavior aligns with the specifications described in #27.
