### PR TITLE
refactor: loose client id requirement and accept `azp`

### DIFF
--- a/packages/mcp-auth/src/utils/create-verify-jwt.ts
+++ b/packages/mcp-auth/src/utils/create-verify-jwt.ts
@@ -59,7 +59,13 @@ export const createVerifyJwt = (
         cause: 'The JWT payload does not contain the `sub` field or it is malformed.',
       });
     }
-
+    /*
+     * Accept either `client_id` (RFC 9068) or `azp` claim for better compatibility.
+     * While `client_id` is required by RFC 9068 for JWT access tokens, many providers
+     * (Auth0, Microsoft, Google) may use or support `azp` claim.
+     *
+     * See: https://github.com/mcp-auth/js/issues/28 for detailed discussion
+     */
     const clientId = payload.client_id ?? payload.azp;
 
     return {

--- a/packages/mcp-auth/src/utils/create-verify-jwt.ts
+++ b/packages/mcp-auth/src/utils/create-verify-jwt.ts
@@ -1,5 +1,5 @@
 import { type AuthInfo } from '@modelcontextprotocol/sdk/server/auth/types.js';
-import { tryThat } from '@silverhand/essentials';
+import { cond, tryThat } from '@silverhand/essentials';
 import { jwtVerify, type JWTVerifyGetKey, type JWTVerifyOptions } from 'jose';
 import { JOSEError } from 'jose/errors';
 
@@ -54,21 +54,17 @@ export const createVerifyJwt = (
       });
     }
 
-    if (typeof payload.client_id !== 'string' || !payload.client_id) {
-      throw new MCPAuthTokenVerificationError('invalid_token', {
-        cause: 'The JWT payload does not contain the `client_id` field or it is malformed.',
-      });
-    }
-
     if (typeof payload.sub !== 'string' || !payload.sub) {
       throw new MCPAuthTokenVerificationError('invalid_token', {
         cause: 'The JWT payload does not contain the `sub` field or it is malformed.',
       });
     }
 
+    const clientId = payload.client_id ?? payload.azp;
+
     return {
       issuer: payload.iss,
-      clientId: payload.client_id,
+      clientId: cond(typeof clientId === 'string' && clientId) ?? '',
       scopes: getScopes(payload.scope) ?? getScopes(payload.scopes) ?? [],
       token,
       audience: payload.aud,

--- a/packages/mcp-auth/src/utils/create-verify-jwt.ts
+++ b/packages/mcp-auth/src/utils/create-verify-jwt.ts
@@ -1,5 +1,5 @@
 import { type AuthInfo } from '@modelcontextprotocol/sdk/server/auth/types.js';
-import { cond, tryThat } from '@silverhand/essentials';
+import { tryThat } from '@silverhand/essentials';
 import { jwtVerify, type JWTVerifyGetKey, type JWTVerifyOptions } from 'jose';
 import { JOSEError } from 'jose/errors';
 
@@ -64,7 +64,7 @@ export const createVerifyJwt = (
 
     return {
       issuer: payload.iss,
-      clientId: cond(typeof clientId === 'string' && clientId) ?? '',
+      clientId: typeof clientId === 'string' ? clientId : '',
       scopes: getScopes(payload.scope) ?? getScopes(payload.scopes) ?? [],
       token,
       audience: payload.aud,


### PR DESCRIPTION
## Summary

Fixes #28.

Improved handling of the `client_id` field in `createVerifyJwt` and added support for the `azp` (authorized party) field. The logic now falls back to the `azp` field if `client_id` is missing or malformed. If neither field is valid, it defaults to an empty string.
