### PR TITLE
fix: use `scopes_supported` in OAuth server metadata

### DIFF
--- a/packages/mcp-auth/src/types/oauth.ts
+++ b/packages/mcp-auth/src/types/oauth.ts
@@ -37,7 +37,12 @@ const authorizationServerMetadataObject = Object.freeze({
    * [[RFC7591](https://www.rfc-editor.org/rfc/rfc7591)].
    */
   registration_endpoint: z.string().optional(),
-  scope_supported: z.array(z.string()).optional(),
+  /**
+   * JSON array containing a list of the OAuth 2.0 `scope` values that this authorization server
+   * supports.
+   * [[RFC8414](https://datatracker.ietf.org/doc/html/rfc8414#section-2)]
+   */
+  scopes_supported: z.array(z.string()).optional(),
   /**
    * JSON array containing a list of the OAuth 2.0 `response_type` values that this authorization
    * server supports. The array values used are the same as those used with the `response_types`

--- a/packages/mcp-auth/src/utils/fetch-server-config.test.ts
+++ b/packages/mcp-auth/src/utils/fetch-server-config.test.ts
@@ -89,6 +89,7 @@ describe('fetchServerConfig (OAuth)', () => {
     authorization_endpoint: 'https://example.com/oauth/authorize',
     token_endpoint: 'https://example.com/oauth/token',
     response_types_supported: ['code'],
+    scopes_supported: ['scope1', 'scope2', 'scope3'],
   });
 
   it('should fetch server config using the well-known URL for OAuth', async () => {
@@ -103,6 +104,7 @@ describe('fetchServerConfig (OAuth)', () => {
         authorizationEndpoint: 'https://example.com/oauth/authorize',
         tokenEndpoint: 'https://example.com/oauth/token',
         responseTypesSupported: ['code'],
+        scopesSupported: ['scope1', 'scope2', 'scope3'],
       },
     });
     expect(wellKnown.isDone()).toBe(true);
@@ -120,6 +122,7 @@ describe('fetchServerConfig (OAuth)', () => {
         authorizationEndpoint: 'https://example.com/oauth/authorize',
         tokenEndpoint: 'https://example.com/oauth/token',
         responseTypesSupported: ['code'],
+        scopesSupported: ['scope1', 'scope2', 'scope3'],
       },
     });
     expect(wellKnown.isDone()).toBe(true);
@@ -135,6 +138,7 @@ describe('fetchServerConfig (OIDC)', () => {
         authorization_endpoint: 'https://example.com/authorize',
         token_endpoint: 'https://example.com/token',
         response_types_supported: ['code'],
+        scopes_supported: ['openid', 'profile', 'email'],
       });
     const config = await fetchServerConfig('https://example.com', { type: 'oidc' });
     expect(config).toEqual({
@@ -144,6 +148,7 @@ describe('fetchServerConfig (OIDC)', () => {
         authorizationEndpoint: 'https://example.com/authorize',
         tokenEndpoint: 'https://example.com/token',
         responseTypesSupported: ['code'],
+        scopesSupported: ['openid', 'profile', 'email'],
       },
     });
     expect(wellKnown.isDone()).toBe(true);


### PR DESCRIPTION
According to the [RFC](https://datatracker.ietf.org/doc/html/rfc8414#section-2), the supported scopes filed name should be `scopes_supported` rather than `scope_supported`.